### PR TITLE
Depend on the cmake buildtool to use the cmake build type

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
   <build_depend>tinyxml</build_depend>
   <build_depend>tinyxml_vendor</build_depend>
   <build_depend version_gte="0.2.3">urdfdom_headers</build_depend>
+  
+  <buildtool_depend>cmake</buildtool_depend>
 
   <exec_depend>console_bridge</exec_depend>
   <exec_depend>tinyxml</exec_depend>


### PR DESCRIPTION
This issue was being masked by a spurious low-level buildtool_export depend.

Since this package requires cmake to build it should... require cmake.