### PR TITLE
fix CMake policy 42 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.5 FATAL_ERROR )
 project (urdfdom CXX C)
 
 set (URDF_MAJOR_VERSION 1)


### PR DESCRIPTION
To get rid of the warning: http://ci.ros2.org/job/ci_osx/3164/warnings2Result/new/

Result with this patch: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3166)](http://ci.ros2.org/job/ci_osx/3166/)