### PR TITLE
define M_PI if not defined

### DIFF
--- a/urdf_parser/test/urdf_unit_test.cpp
+++ b/urdf_parser/test/urdf_unit_test.cpp
@@ -5,6 +5,9 @@
 #include <vector>
 #include "urdf_model/pose.h"
 
+#ifndef M_PI
+# define M_PI 3.141592653589793
+#endif
 
 bool quat_are_near(urdf::Rotation left, urdf::Rotation right)
 {


### PR DESCRIPTION
cmath doesnt provide M_PI on Windows, this test gets the definition from "urdf_model/pose.h" that is not very robust to changes.

This change is needed to be start tracking upstream `urdfdom_headers` again.

Connects to ros2/ros2#465