### PR TITLE
avoid adding non-existing link directory

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -28,7 +28,10 @@ target_link_libraries(urdf_to_graphiz urdfdom_model)
 add_executable(urdf_mem_test test/memtest.cpp)
 target_link_libraries(urdf_mem_test urdfdom_model)
 
-add_subdirectory(test)
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 INSTALL(
   TARGETS


### PR DESCRIPTION
When tests are not enabled the `add_test` calls don't generate anything. Therefore the directory `${PROJECT_BINARY_DIR}/test` doesn't exist.

Before: https://ci.ros2.org/view/colcon/job/colcon_ci_packaging_osx/6/consoleFull#console-section-164
After: https://ci.ros2.org/view/colcon/job/colcon_ci_packaging_osx/7/consoleFull#console-section-162

This patch only addresses the library warning. It doesn't address the fact that the package performs test specific steps (building gtest, removing test results, etc.) when testing is explicitly disabled.