### PR TITLE
Port upstream PRs 111 and 112 addressing linker warning

### DIFF
--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -28,7 +28,10 @@ target_link_libraries(urdf_to_graphiz urdfdom_model)
 add_executable(urdf_mem_test test/memtest.cpp)
 target_link_libraries(urdf_mem_test urdfdom_model)
 
-add_subdirectory(test)
+include(CTest)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 INSTALL(
   TARGETS

--- a/urdf_parser/test/CMakeLists.txt
+++ b/urdf_parser/test/CMakeLists.txt
@@ -4,11 +4,6 @@ include_directories (
   ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-link_directories(
-  ${PROJECT_BINARY_DIR}/test
-)
-
-
 # Build gtest
 add_library(gtest STATIC gtest/src/gtest-all.cc)
 add_library(gtest_main STATIC gtest/src/gtest_main.cc)


### PR DESCRIPTION
Replaces #10.

Port of ros/urdfdom#111 and ros/urdfdom#112 addressing a linker warning.

CI builds up to `urdf_parser`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4326)](http://ci.ros2.org/job/ci_linux/4326/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1317)](http://ci.ros2.org/job/ci_linux-aarch64/1317/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3553)](http://ci.ros2.org/job/ci_osx/3553/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4401)](http://ci.ros2.org/job/ci_windows/4401/)

Packaging build on macOS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_osx&build=32)](https://ci.ros2.org/job/ci_packaging_osx/32/) (https://ci.ros2.org/job/ci_packaging_osx/32/consoleFull#console-section-172)