### PR TITLE
2.0.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>urdfdom</name>
-  <version>0.3.0</version>
+  <version>2.0.0</version>
   <description>A library to access URDFs using the DOM model.</description>
   <maintainer email="steven@osrfoundation.org">Steven! Ragnarök</maintainer>
 


### PR DESCRIPTION
Per @mikaelarguedas as our fork is based on the boost-free version of upstream we'll bump the major version up one from theirs to allow headroom.

To be fast-forwarded onto `ros2` if approved.