### PR TITLE
Use CMake targets instead of variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(tinyxml_vendor REQUIRED)
 find_package(TinyXML REQUIRED)
-include_directories(SYSTEM ${TinyXML_INCLUDE_DIRS})
 
 find_package(urdfdom_headers 1.0 REQUIRED)
-include_directories(SYSTEM ${urdfdom_headers_INCLUDE_DIRS})
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -46,8 +44,6 @@ endif()
 
 find_package(console_bridge_vendor REQUIRED) # Provides console_bridge 0.4.0 on platforms without it.
 find_package(console_bridge REQUIRED)
-include_directories(SYSTEM ${console_bridge_INCLUDE_DIRS})
-link_directories(${console_bridge_LIBRARY_DIRS})
 
 #In Visual Studio a special postfix for 
 #libraries compiled in debug is used

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(urdfdom_model SHARED
   src/link.cpp
   src/joint.cpp)
 target_include_directories(urdfdom_model PUBLIC
+  ${TinyXML_INCLUDE_DIRS}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(urdfdom_model PUBLIC
@@ -15,6 +16,7 @@ set_target_properties(urdfdom_model PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERS
 add_library(urdfdom_world SHARED
   src/world.cpp)
 target_include_directories(urdfdom_world PUBLIC
+  ${TinyXML_INCLUDE_DIRS}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(urdfdom_world PUBLIC
@@ -26,6 +28,7 @@ set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERS
 
 add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
 target_include_directories(urdfdom_sensor PUBLIC
+  ${TinyXML_INCLUDE_DIRS}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(urdfdom_sensor PUBLIC
@@ -39,6 +42,7 @@ add_library(urdfdom_model_state SHARED
   src/urdf_model_state.cpp
   src/twist.cpp)
 target_include_directories(urdfdom_model_state PUBLIC
+  ${TinyXML_INCLUDE_DIRS}
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(urdfdom_model_state

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -1,29 +1,50 @@
-add_library(urdfdom_world SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp src/world.cpp)
-target_include_directories(urdfdom_world PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-target_link_libraries(urdfdom_world ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
-set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
-
-add_library(urdfdom_model SHARED src/pose.cpp src/model.cpp src/link.cpp src/joint.cpp)
+add_library(urdfdom_model SHARED
+  src/pose.cpp
+  src/model.cpp
+  src/link.cpp
+  src/joint.cpp)
 target_include_directories(urdfdom_model PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
-target_link_libraries(urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(urdfdom_model PUBLIC
+  console_bridge::console_bridge
+  urdfdom_headers::urdfdom_headers
+  ${TinyXML_LIBRARIES})
 set_target_properties(urdfdom_model PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
+
+add_library(urdfdom_world SHARED
+  src/world.cpp)
+target_include_directories(urdfdom_world PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_link_libraries(urdfdom_world PUBLIC
+  urdfdom_model
+  console_bridge::console_bridge
+  urdfdom_headers::urdfdom_headers
+  ${TinyXML_LIBRARIES})
+set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
 add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
 target_include_directories(urdfdom_sensor PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
-target_link_libraries(urdfdom_sensor urdfdom_model ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(urdfdom_sensor PUBLIC
+  urdfdom_model
+  console_bridge::console_bridge
+  urdfdom_headers::urdfdom_headers
+  ${TinyXML_LIBRARIES})
 set_target_properties(urdfdom_sensor PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
-add_library(urdfdom_model_state SHARED src/urdf_model_state.cpp src/twist.cpp)
+add_library(urdfdom_model_state SHARED
+  src/urdf_model_state.cpp
+  src/twist.cpp)
 target_include_directories(urdfdom_model_state PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
-target_link_libraries(urdfdom_model_state ${TinyXML_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(urdfdom_model_state
+  console_bridge::console_bridge
+  urdfdom_headers::urdfdom_headers
+  ${TinyXML_LIBRARIES})
 set_target_properties(urdfdom_model_state PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
 # --------------------------------

--- a/urdf_parser/CMakeLists.txt
+++ b/urdf_parser/CMakeLists.txt
@@ -1,3 +1,19 @@
+add_library(urdfdom_world SHARED
+  src/pose.cpp
+  src/model.cpp
+  src/link.cpp
+  src/joint.cpp
+  src/world.cpp)
+target_include_directories(urdfdom_world PUBLIC
+  ${TinyXML_INCLUDE_DIRS}
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
+target_link_libraries(urdfdom_world PUBLIC
+  console_bridge::console_bridge
+  urdfdom_headers::urdfdom_headers
+  ${TinyXML_LIBRARIES})
+set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
+
 add_library(urdfdom_model SHARED
   src/pose.cpp
   src/model.cpp
@@ -12,19 +28,6 @@ target_link_libraries(urdfdom_model PUBLIC
   urdfdom_headers::urdfdom_headers
   ${TinyXML_LIBRARIES})
 set_target_properties(urdfdom_model PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
-
-add_library(urdfdom_world SHARED
-  src/world.cpp)
-target_include_directories(urdfdom_world PUBLIC
-  ${TinyXML_INCLUDE_DIRS}
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-target_link_libraries(urdfdom_world PUBLIC
-  urdfdom_model
-  console_bridge::console_bridge
-  urdfdom_headers::urdfdom_headers
-  ${TinyXML_LIBRARIES})
-set_target_properties(urdfdom_world PROPERTIES SOVERSION ${URDF_MAJOR_MINOR_VERSION})
 
 add_library(urdfdom_sensor SHARED src/urdf_sensor.cpp)
 target_include_directories(urdfdom_sensor PUBLIC


### PR DESCRIPTION
Fixes `urdfdom` not exporting a transitive dependency on `urdfdom_headers` in its exported targets. This makes the targets use CMake exported targets instead of old-style CMake variables.

~~I also made `urdf_world` depend on `urdf_model` - before `urdf_world` was building all of `urdf_model`'s sources plus `world.cpp`.~~ *edit* had to undo this because windows

more info here: https://github.com/ros2/urdf/pull/17#discussion_r488286580